### PR TITLE
Add navigation to index_2 and restore page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,21 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # hello_codex
+
+This repository contains a minimal static site that can be published with GitHub Pages. `index.html` serves as the entry point and links to `best-practices.html` through a simple navigation menu.
+
+The `.github/workflows/pages.yml` workflow automates deployment so pushing to `main` updates the site automatically.
+
+## Publishing with GitHub Pages
+
+1. Open the repository's **Settings** and locate the **Pages** section.
+2. Choose **Deploy from a branch** and select the `main` branch with the root folder.
+3. Save the configuration. GitHub will provide the URL where the site is hosted.
+
+Once enabled, navigate to the provided URL to see the site in action.

--- a/best-practices.html
+++ b/best-practices.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Code Best Practices</title>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a> |
+      <a href="index_2.html">Index 2</a> |
+      <a href="best-practices.html">Best Practices</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Best Practices for Using Code</h1>
+    <p>Here are a few tips to help keep your code clean and maintainable:</p>
+    <ul>
+      <li><strong>Write clear comments:</strong> Explain the purpose of complex logic so others can understand your work.</li>
+      <li><strong>Be consistent with formatting:</strong> Use the same indentation and naming conventions throughout your project.</li>
+      <li><strong>Break tasks into functions:</strong> Smaller, reusable functions make your code easier to test and debug.</li>
+      <li><strong>Version control:</strong> Use a tool like Git to track changes and collaborate with others.</li>
+      <li><strong>Test your code:</strong> Automated tests help ensure your code works as expected as you make changes.</li>
+    </ul>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
     header { background-color: #4b2e83; color: #fff; padding: 2rem; text-align: center; }
+    nav { margin-top: 1rem; }
     main { padding: 2rem; }
     section { margin-bottom: 1.5rem; }
     footer { background-color: #eee; text-align: center; padding: 1rem; }
@@ -16,6 +17,11 @@
   <header>
     <h1>Welcome to Codex</h1>
     <p>The place where humans and AI collaborate on code.</p>
+    <nav>
+      <a href="index.html">Home</a> |
+      <a href="index_2.html">Index 2</a> |
+      <a href="best-practices.html">Best Practices</a>
+    </nav>
   </header>
   <main>
     <section id="about">

--- a/index_2.html
+++ b/index_2.html
@@ -1,19 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Code Best Practices</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Index 2</title>
 </head>
 <body>
-    <h1>Best Practices for Using Code</h1>
-    <p>Here are a few tips to help keep your code clean and maintainable:</p>
-    <ul>
-        <li><strong>Write clear comments:</strong> Explain the purpose of complex logic so others can understand your work.</li>
-        <li><strong>Be consistent with formatting:</strong> Use the same indentation and naming conventions throughout your project.</li>
-        <li><strong>Break tasks into functions:</strong> Smaller, reusable functions make your code easier to test and debug.</li>
-        <li><strong>Version control:</strong> Use a tool like Git to track changes and collaborate with others.</li>
-        <li><strong>Test your code:</strong> Automated tests help ensure your code works as expected as you make changes.</li>
-    </ul>
+  <header>
+    <nav>
+      <a href="index.html">Home</a> |
+      <a href="index_2.html">Index 2</a> |
+      <a href="best-practices.html">Best Practices</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Second Index Page</h1>
+    <p>This page demonstrates navigation across multiple entry points.</p>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add nav link to index_2 from index.html and best-practices.html
- restore index_2.html page for navigation
- keep GitHub Pages workflow for deployment

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684237971d308326b42c4f4112922d4b